### PR TITLE
Zmieniono nazwę tagu instancji w pliku main.tf na \PythonAppInstance_…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "aws_instance" "app" {
   instance_type = "t2.micro"
 
   tags = {
-    Name = "PythonAppInstance_2025"
+    Name = "PythonAppInstance_2025_testowy"
   }
 }
 


### PR DESCRIPTION
…2025_testowy\
This pull request includes a small change to the `main.tf` file. The change updates the `Name` tag for the `aws_instance` resource to "PythonAppInstance_2025_testowy" for testing purposes.

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL10-R10): Updated the `Name` tag for the `aws_instance` resource to "PythonAppInstance_2025_testowy".